### PR TITLE
Throw ServiceException when setTimeout() == false

### DIFF
--- a/src/IpIntel/IpIntel.php
+++ b/src/IpIntel/IpIntel.php
@@ -68,7 +68,7 @@ final class IpIntel implements IpIntelInterface
             $data
         );
 
-        if ($response < 0 || strcmp($response, "") == 0) {
+        if (empty($response) || $response < 0 || strcmp($response, "") == 0) {
             throw new Exception\ServiceException();
         }
 


### PR DESCRIPTION
`Uncaught TypeError: strcmp() expects parameter 1 to be string, bool given in...`

I'm not sure the exact scenario this happens, but handling it as ServiceException is correct.

I think the addition of `empty($response)` negates the need for `strcmp($response, "") == 0`.

I'm using this library for anti-fraud by disabling credit card use in WooCommerce when a customer is on a VPN, thank you.
https://github.com/BrianHenryIE/bh-wc-csp-condition-ip-address